### PR TITLE
fixes delay on initial spinner firing

### DIFF
--- a/SwiftUI-Animation/Animations/LoadingSpinner/Spinner.swift
+++ b/SwiftUI-Animation/Animations/LoadingSpinner/Spinner.swift
@@ -40,6 +40,7 @@ struct Spinner: View {
             }.frame(width: 200, height: 200)
         }
         .onAppear() {
+            self.animateSpinner()
             Timer.scheduledTimer(withTimeInterval: animationTime, repeats: true) { (mainTimer) in
                 self.animateSpinner()
             }


### PR DESCRIPTION
Ran into the same issue documented in #1. Calling animateSpinner() right away onAppear